### PR TITLE
[RNA][Images] Fixing permissions issue

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -228,7 +228,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         List<String> supportedPermissions = new ArrayList<>(requiredPermissions);
 
         // android 11 introduced scoped storage, and WRITE_EXTERNAL_STORAGE no longer works there
-        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.Q) {
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
             supportedPermissions.remove(Manifest.permission.WRITE_EXTERNAL_STORAGE);
         }
 


### PR DESCRIPTION
Fixing an issue where images weren't able to upload for any Android 10 devices. This was because the `supportedPermissions` list by default included `Manifest.permission.WRITE_EXTERNAL_STORAGE`, which was only removed for version codes above Q (Android 10). Since we don't include the external storage permission by [default](https://github.com/discord/discord/blob/main/discord_android_rn/android/app/src/main/AndroidManifest.xml#L29) for Android 10, this will always throw an exception.

Asana: https://app.asana.com/0/1200546912788443/1201897631252202/f