### PR TITLE
fix: "Edit Image" heading lacks accessibility

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/ImageCropPicker.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/ImageCropPicker.java
@@ -323,6 +323,7 @@ class ImageCropPicker implements ActivityEventListener {
             // Toolbar title: mark as accessibility heading
             TextView toolbarTitle = activity.findViewById(com.yalantis.ucrop.R.id.toolbar_title);
             if (toolbarTitle != null) {
+                ViewCompat.setImportantForAccessibility(toolbarTitle, ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_YES);
                 ViewCompat.setAccessibilityHeading(toolbarTitle, true);
             }
 


### PR DESCRIPTION
Can be squashed into the prior a11y commit.

This [change](https://github.com/ivpusic/react-native-image-crop-picker/commit/d167b985f69586c09c7a82dd529176ad953ae9de) almost fixed that, but lacked setting important for accessibility. 