### PR TITLE
[android] Fix image crop math to properly upscale

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/ImageCropPicker.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/ImageCropPicker.java
@@ -1479,9 +1479,23 @@ class ImageCropPicker implements ActivityEventListener {
             if (resultUri != null) {
                 try {
                     if (width > 0 && height > 0) {
+                        int targetWidth = width;
+                        int targetHeight = height;
+                        if (freeStyleCropEnabled) {
+                            // Fit-in-size: uniformly scale by the smaller axis ratio so the output fits
+                            // within (width, height) while preserving the cropped image's aspect ratio.
+                            // See ivpusic/react-native-image-crop-picker#1690.
+                            int cropWidth = data.getIntExtra(UCrop.EXTRA_OUTPUT_IMAGE_WIDTH, 0);
+                            int cropHeight = data.getIntExtra(UCrop.EXTRA_OUTPUT_IMAGE_HEIGHT, 0);
+                            if (cropWidth > 0 && cropHeight > 0) {
+                                float scaleRatio = Math.min((float) width / cropWidth, (float) height / cropHeight);
+                                targetWidth = Math.round(cropWidth * scaleRatio);
+                                targetHeight = Math.round(cropHeight * scaleRatio);
+                            }
+                        }
                         File resized = null;
                         try{
-                            resized = compression.resize(this.reactContext, resultUri.getPath(), width, height, width, height, 100, getMimeType(resultUri.toString()));
+                            resized = compression.resize(this.reactContext, resultUri.getPath(), targetWidth, targetHeight, targetWidth, targetHeight, 100, getMimeType(resultUri.toString()));
                         } catch (OutOfMemoryError ex) {
                                  resultCollector.notifyProblem(E_LOW_MEMORY_ERROR, ex.getMessage());
                         }


### PR DESCRIPTION
Native fix for the issue described in https://github.com/discord/discord/pull/283469.

### Context

Audited where we use this library since I'm modifying the core crop logic. The message composer is the only place that sets `freeStyleCropEnabled` when editing media. The other usages are for uploading assets, such as avatars or stickers. These usages omit `freeStyleCropEnabled` and pass a height and width. This forces the crop controls to have a fixed aspect ratio. As a result, the cropped image is scaled properly even if the user zooms in, zooms out, or repositions the crop container. 

To perhaps better visualize this, user profile banners set the dimensions as 1080x432 or a 5:2 aspect ratio. Since we omit `freeStyleCropEnabled`, the aspect ratio of the crop tool is fixed. If the user uploads a 256x256 image, the initial crop container will be 256x102 (the 5:2 ratio). If the user zooms in, the ratio is preserved, say to a 100x40 region. When they apply the crop, the image will be upscaled back tot he original dimensions when the resize logic runs:
```kotlin
compression.resize(this.reactContext, resultUri.getPath(), 1080, 432, 1080, 432, 100, getMimeType(resultUri.toString()));
```

The upscaled image is not stretched or squished because the aspect ratio is preserved. However, I think the problem with `freeStyleCropEnabled` is that the aspect ratio of the crop can _diverge_ from the aspect ratio of the original image. When the user then applies the crop, the resize logic stretches or squishes the cropped image back to the original dimensions / aspect ratio. 

### Changes

To fix this, we check if `freeStyleCropEnabled` is enabled and the image is cropped. If so, then we uniformly scale the cropped image to fit within original image dimensions while preserving aspect ratio. The paths where `freeStyleCropEnabled` is omitted should not be affected / already work properly.  

Tested this by taking a large screenshot and then performing the same crop on the current stable app, with the original JS fix, and with this new native fix (no JS changes). Both the JS and native fixes produce the correct aspect ratio, but the native one is also upscaled properly.

### Original Image (1080x2220)

<img width="1080" height="2220" alt="original image" src="https://github.com/user-attachments/assets/310aa60d-77e6-4b75-aba1-29039b7500b5" />

### Current Behavior (1080x2220)

<img width="1080" height="2220" alt="crop, current fix version" src="https://github.com/user-attachments/assets/89f1ebee-1c34-4f27-a585-b03fe364a74f" />

### After JS Fix (496x536)

<img width="496" height="536" alt="crop, js fix version" src="https://github.com/user-attachments/assets/1047541a-cc83-4c81-bccf-b3575ca2d5cd" />

### After Native Fix (1080x1095)

<img width="1080" height="1095" alt="crop, native fix version" src="https://github.com/user-attachments/assets/62fd12c3-bf89-4e8e-b4b6-d2a7ba106f39" />


