### PR TITLE
[Android] Fix bottom tab label color

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/ImageCropPicker.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/ImageCropPicker.java
@@ -592,8 +592,9 @@ class ImageCropPicker implements ActivityEventListener {
             View stateView = activity.findViewById(stateId);
             if (stateView == null) return;
 
-            ImageView imageView = activity.findViewById(imageViewId);
-            TextView textView = activity.findViewById(textViewId);
+            // Find views within tab wrapper
+            ImageView imageView = stateView.findViewById(imageViewId);
+            TextView textView = stateView.findViewById(textViewId);
 
             // Apply colors to the icon using a color state list drawable
             if (imageView != null && imageView.getDrawable() != null) {


### PR DESCRIPTION
## Description

[Asana](https://app.asana.com/1/236888843494340/project/1197438383943832/task/1215071847691068?focus=true)

Follow up from [discord/discord#289557](https://github.com/discord/discord/pull/289557) 

Small fix so that the bottom tab active label correctly applies the `cropperActiveWidgetColor`. The reason the color wasn't being applied is because we were using `activity.findViewById(textViewId)` which would return the first match globally vs scoped to just the tabs --> color applied to a different view instead and the label would just use the default white.

## Screenshots

| Before | After |
| --- | --- |
| <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/ff2afa39-3cf2-4baf-9a00-8bc6a6e35b33" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/ce303b3c-06d5-4c83-b3d3-45373c2e1e8c" /> |
| <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/d2df60b7-2296-434a-81f3-7442b06dc39f" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/96eb35fe-ddd7-4acf-a944-99c61f8efcd6" /> |