### PR TITLE
Persists cropper customization across Android configuration changes

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/ImageCropPicker.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/ImageCropPicker.java
@@ -84,15 +84,8 @@ class ImageCropPicker implements ActivityEventListener {
      * As such we use a lifecycle callback to apply the colors to the `uCrop` activity 
      * once it is created via lifecycle callbacks.
      */
-    private static String pendingCropperControlsColor = null;
-    private static String pendingCropperControlsBarColor = null;
-    private static String pendingCropperActiveWidgetColor = null;
-    private static String pendingCropperInactiveWidgetColor = null;
     private static Application.ActivityLifecycleCallbacks ucropLifecycleCallbacks = null;
     private static Application.ActivityLifecycleCallbacks ucropAccessibilityCallbacks = null;
-    private static String pendingCropperCancelText = null;
-    private static String pendingCropperRotateByAngleAccessibilityLabel = null;
-    private static String pendingCropperResetRotationAccessibilityLabel = null;
 
     private static final String E_PICKER_CANCELLED_KEY = "E_PICKER_CANCELLED";
     private static final String E_PICKER_CANCELLED_MSG = "User cancelled image selection";
@@ -163,6 +156,9 @@ class ImageCropPicker implements ActivityEventListener {
      * improvement could be to modify `uCrop` to expose these colors to the public API.
      */
     private void registerUCropLifecycleCallback(Activity activity) {
+        // Unregister any existing callback first
+        unregisterUCropLifecycleCallback(activity);
+        
         // Check if any custom colors need to be applied
         boolean hasCustomColors = cropperControlsColor != null 
             || cropperControlsBarColor != null
@@ -174,13 +170,10 @@ class ImageCropPicker implements ActivityEventListener {
         }
 
         // Store the colors for the callback to use
-        pendingCropperControlsColor = cropperControlsColor;
-        pendingCropperControlsBarColor = cropperControlsBarColor;
-        pendingCropperActiveWidgetColor = cropperActiveWidgetColor;
-        pendingCropperInactiveWidgetColor = cropperInactiveWidgetColor;
-
-        // Unregister any existing callback first
-        unregisterUCropLifecycleCallback(activity);
+        final String pendingCropperControlsColor = cropperControlsColor;
+        final String pendingCropperControlsBarColor = cropperControlsBarColor;
+        final String pendingCropperActiveWidgetColor = cropperActiveWidgetColor;
+        final String pendingCropperInactiveWidgetColor = cropperInactiveWidgetColor;
 
         ucropLifecycleCallbacks = new Application.ActivityLifecycleCallbacks() {
             @Override
@@ -228,12 +221,11 @@ class ImageCropPicker implements ActivityEventListener {
 
             @Override
             public void onActivityDestroyed(Activity activity) {
-                if (activity instanceof UCropActivity) {
-                    // Clean up when UCropActivity is destroyed
-                    pendingCropperControlsColor = null;
-                    pendingCropperControlsBarColor = null;
-                    pendingCropperActiveWidgetColor = null;
-                    pendingCropperInactiveWidgetColor = null;
+                if (activity instanceof UCropActivity && !activity.isChangingConfigurations()) {
+                    // Clean up when UCropActivity is being destroyed and not shown again
+                    // Note: when an activity goes through a configuration change (e.g. screen rotation),
+                    // onDestroyed is called and a new activity is created. We want to persist our custom
+                    // colors across those kinds of changes.
                     unregisterUCropLifecycleCallback(activity);
                 }
             }
@@ -256,11 +248,11 @@ class ImageCropPicker implements ActivityEventListener {
      * Registers a lifecycle callback to apply accessibility attributes to UCropActivity.
      */
     private void registerUCropAccessibilityCallback(Activity activity) {
-        pendingCropperCancelText = cropperCancelText;
-        pendingCropperRotateByAngleAccessibilityLabel = cropperRotateByAngleAccessibilityLabel;
-        pendingCropperResetRotationAccessibilityLabel = cropperResetRotationAccessibilityLabel;
-
         unregisterUCropAccessibilityCallback(activity);
+        
+        final String pendingCropperCancelText = cropperCancelText;
+        final String pendingCropperRotateByAngleAccessibilityLabel = cropperRotateByAngleAccessibilityLabel;
+        final String pendingCropperResetRotationAccessibilityLabel = cropperResetRotationAccessibilityLabel;
 
         ucropAccessibilityCallbacks = new Application.ActivityLifecycleCallbacks() {
             @Override
@@ -273,7 +265,9 @@ class ImageCropPicker implements ActivityEventListener {
             public void onActivityResumed(Activity activity) {
                 if (activity instanceof UCropActivity) {
                     activity.getWindow().getDecorView().post(() -> {
-                        applyAccessibility(activity);
+                        applyAccessibility(activity, pendingCropperCancelText, 
+                            pendingCropperRotateByAngleAccessibilityLabel, 
+                            pendingCropperResetRotationAccessibilityLabel);
                     });
                 }
             }
@@ -289,10 +283,7 @@ class ImageCropPicker implements ActivityEventListener {
 
             @Override
             public void onActivityDestroyed(Activity activity) {
-                if (activity instanceof UCropActivity) {
-                    pendingCropperCancelText = null;
-                    pendingCropperRotateByAngleAccessibilityLabel = null;
-                    pendingCropperResetRotationAccessibilityLabel = null;
+                if (activity instanceof UCropActivity && !activity.isChangingConfigurations()) {
                     unregisterUCropAccessibilityCallback(activity);
                 }
             }
@@ -312,12 +303,13 @@ class ImageCropPicker implements ActivityEventListener {
      * Applies accessibility attributes to UCropActivity views: content descriptions,
      * heading role on the title, and button roles on the bottom tabs.
      */
-    private void applyAccessibility(Activity activity) {
+    private void applyAccessibility(Activity activity, String cropperCancelText, 
+        String cropperRotateByAngleAccessibilityLabel, String cropperResetRotationAccessibilityLabel) {
         try {
             // Toolbar: set navigation icon (X) content description from cropperCancelText
             Toolbar toolbar = activity.findViewById(com.yalantis.ucrop.R.id.toolbar);
-            if (toolbar != null && pendingCropperCancelText != null) {
-                toolbar.setNavigationContentDescription(pendingCropperCancelText);
+            if (toolbar != null && cropperCancelText != null) {
+                toolbar.setNavigationContentDescription(cropperCancelText);
             }
 
             // Toolbar title: mark as accessibility heading
@@ -338,8 +330,8 @@ class ImageCropPicker implements ActivityEventListener {
             // Rotate by angle (90-degree) button
             View rotateByAngle = activity.findViewById(com.yalantis.ucrop.R.id.wrapper_rotate_by_angle);
             if (rotateByAngle != null) {
-                if (pendingCropperRotateByAngleAccessibilityLabel != null) {
-                    rotateByAngle.setContentDescription(pendingCropperRotateByAngleAccessibilityLabel);
+                if (cropperRotateByAngleAccessibilityLabel != null) {
+                    rotateByAngle.setContentDescription(cropperRotateByAngleAccessibilityLabel);
                 }
                 setButtonRole(rotateByAngle);
             }
@@ -347,8 +339,8 @@ class ImageCropPicker implements ActivityEventListener {
             // Reset rotation button
             View resetRotate = activity.findViewById(com.yalantis.ucrop.R.id.wrapper_reset_rotate);
             if (resetRotate != null) {
-                if (pendingCropperResetRotationAccessibilityLabel != null) {
-                    resetRotate.setContentDescription(pendingCropperResetRotationAccessibilityLabel);
+                if (cropperResetRotationAccessibilityLabel != null) {
+                    resetRotate.setContentDescription(cropperResetRotationAccessibilityLabel);
                 }
                 setButtonRole(resetRotate);
             }


### PR DESCRIPTION
## Task
[[Other] When On White Theme, Rotating To Landscape In The Icon Editor Will Change The Theme Of The Bottom Elements](https://app.asana.com/1/236888843494340/project/1197438383943832/task/1216125630705184)

##  Description
- We customize the footer in the cropper to have a custom color (based on theme) and to have some custom a11y attribution. 
- The core library does not directly support these customizations so we do this by attaching an ActivityLifecycleCallbacks listener so we can manually apply our customizations in onResume
- When the user rotates their device, the existing activity is destroyed (which calls our onDestroy handler) and then recreated
- Previously, we were removing our listener in onDestory. In the event of a configuration change, that meant we removed our listener during tear down and didn't re-apply our customizations in the subsequent onResume for the new activity
- In our onDestroy, we can check to see if the activity is currently going through a configuration change - this signals to us that the activity will be subsequently recreated. In this case, we do NOT want to remove our listener. As a result, onResume gets called on the new activity and our customizations persist across the configuration change.

## Demo
Pay special attention to the footer color and the talk back descriptions before and after rotation

### Before
https://github.com/user-attachments/assets/297ffc1b-0fe4-4b31-9ccb-b1e5022208e5

### After
https://github.com/user-attachments/assets/efd0fc27-95f7-47ae-8f46-87bff978f43a



